### PR TITLE
feat(email): Phase 1 — send-pipeline foundations & kill-switch integrity

### DIFF
--- a/functions/src/__tests__/emailTemplateHelper.spec.ts
+++ b/functions/src/__tests__/emailTemplateHelper.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getEmailTemplate, createOtpEmailLog, createWelcomeEmailLog } from '../utils/emailTemplateHelper.js';
 import { db } from '../init.js';
+import { queueEmail } from '../email-core/queueEmail.js';
 
 // Mock init and constant
 vi.mock('../init', () => ({
@@ -13,11 +14,18 @@ vi.mock('../constant', () => ({
   constant: {},
 }));
 
+// The create* helpers now delegate to the queueEmail() chokepoint.
+vi.mock('../email-core/queueEmail', () => ({
+  queueEmail: vi.fn().mockResolvedValue({ id: 'log-1', status: 'pending' }),
+}));
+
 describe('emailTemplateHelper', () => {
   const mockDb = db as any;
+  const mockQueueEmail = vi.mocked(queueEmail);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQueueEmail.mockResolvedValue({ id: 'log-1', status: 'pending' });
   });
 
   describe('getEmailTemplate', () => {
@@ -88,27 +96,12 @@ describe('emailTemplateHelper', () => {
   });
 
   describe('createOtpEmailLog', () => {
-    it('should create correct email log', async () => {
-      const mockAdd = vi.fn();
-      const mockSettingsGet = vi.fn().mockResolvedValue({
-        exists: true,
-        data: () => ({ bccEmail: 'admin@test.com' }),
-      });
-
-      const mockCollection = vi.fn((name) => {
-        if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
-        if (name === 'EmailLogs') return { add: mockAdd };
-        return { doc: vi.fn() };
-      });
-
-      mockDb.collection = mockCollection;
-
+    it('should queue a transactional waitlist OTP email', async () => {
       const userData = {
         email: 'test@user.com',
         verificationCode: '123456',
         waitlistId: 'wl-123',
       };
-
       const templateData = {
         senderEmail: 'sender@test.com',
         senderName: 'Sender',
@@ -119,29 +112,19 @@ describe('emailTemplateHelper', () => {
 
       await createOtpEmailLog(userData as any, templateData as any);
 
-      expect(mockCollection).toHaveBeenCalledWith('Settings');
-      expect(mockCollection).toHaveBeenCalledWith('EmailLogs');
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({
+        source: 'waitlist',
+        category: 'transactional',
         toEmail: 'test@user.com',
-        otp: '123456',
         subject: 'Subject',
-        bcc: 'admin@test.com',
+        type: 'waitlist_verify_otp_email',
         // No firstName/name → falls back to email prefix
         toName: 'test',
-        name: 'test',
+        data: expect.objectContaining({ otp: '123456' }),
       }));
     });
 
     it('should use firstName when available (not email prefix)', async () => {
-      const mockAdd = vi.fn();
-      const mockSettingsGet = vi.fn().mockResolvedValue({ exists: false, data: () => ({}) });
-      const mockCollection = vi.fn((name) => {
-        if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
-        if (name === 'EmailLogs') return { add: mockAdd };
-        return { doc: vi.fn() };
-      });
-      mockDb.collection = mockCollection;
-
       const userData = {
         email: 'gunjan+test1@example.com',
         firstName: 'Gunjan Karun',
@@ -154,22 +137,12 @@ describe('emailTemplateHelper', () => {
 
       await createOtpEmailLog(userData as any, templateData as any);
 
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({
         toName: 'Gunjan Karun',
-        name: 'Gunjan Karun',
       }));
     });
 
     it('should fall back to name field when firstName is absent', async () => {
-      const mockAdd = vi.fn();
-      const mockSettingsGet = vi.fn().mockResolvedValue({ exists: false, data: () => ({}) });
-      const mockCollection = vi.fn((name) => {
-        if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
-        if (name === 'EmailLogs') return { add: mockAdd };
-        return { doc: vi.fn() };
-      });
-      mockDb.collection = mockCollection;
-
       const userData = {
         email: 'gunjan+test1@example.com',
         name: 'Full Name',
@@ -182,22 +155,12 @@ describe('emailTemplateHelper', () => {
 
       await createOtpEmailLog(userData as any, templateData as any);
 
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({
         toName: 'Full Name',
-        name: 'Full Name',
       }));
     });
 
     it('should fall back to email prefix when both firstName and name are absent', async () => {
-      const mockAdd = vi.fn();
-      const mockSettingsGet = vi.fn().mockResolvedValue({ exists: false, data: () => ({}) });
-      const mockCollection = vi.fn((name) => {
-        if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
-        if (name === 'EmailLogs') return { add: mockAdd };
-        return { doc: vi.fn() };
-      });
-      mockDb.collection = mockCollection;
-
       const userData = {
         email: 'gunjan+test1@example.com',
         verificationCode: '222222',
@@ -209,36 +172,28 @@ describe('emailTemplateHelper', () => {
 
       await createOtpEmailLog(userData as any, templateData as any);
 
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({
         toName: 'gunjan+test1',
-        name: 'gunjan+test1',
       }));
+    });
+
+    it('should pass templateIsActive=false through to queueEmail', async () => {
+      await createOtpEmailLog(
+        { email: 'a@b.com', verificationCode: '1', waitlistId: 'w' } as any,
+        { senderEmail: 's', senderName: 'S', subject: 'x', template: 'y', type: 'waitlist_verify_otp_email', isActive: false } as any,
+      );
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({ templateIsActive: false }));
     });
   });
 
   describe('createWelcomeEmailLog', () => {
-    it('should create correct welcome email log', async () => {
-      const mockAdd = vi.fn();
-      const mockSettingsGet = vi.fn().mockResolvedValue({
-        exists: true,
-        data: () => ({ bccEmail: 'admin@test.com' }),
-      });
-
-      const mockCollection = vi.fn((name) => {
-        if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
-        if (name === 'EmailLogs') return { add: mockAdd };
-        return { doc: vi.fn() };
-      });
-
-      mockDb.collection = mockCollection;
-
+    it('should queue a marketing waitlist welcome email', async () => {
       const userData = {
         email: 'test@user.com',
         firstName: 'Tester',
         waitlistId: 'wl-123',
         referralLink: 'ref-link',
       };
-
       const templateData = {
         senderEmail: 'sender@test.com',
         senderName: 'Sender',
@@ -249,15 +204,27 @@ describe('emailTemplateHelper', () => {
 
       await createWelcomeEmailLog(userData as any, templateData as any, 'My Waitlist');
 
-      expect(mockCollection).toHaveBeenCalledWith('Settings');
-      expect(mockCollection).toHaveBeenCalledWith('EmailLogs');
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({
+        source: 'waitlist',
+        category: 'marketing',
         toEmail: 'test@user.com',
         toName: 'Tester',
         subject: 'Welcome',
-        waitlistName: 'My Waitlist',
-        referralLink: 'ref-link'
+        // default: subscribed unless explicitly false
+        isSubscribed: true,
+        data: expect.objectContaining({
+          waitlistName: 'My Waitlist',
+          referralLink: 'ref-link',
+        }),
       }));
+    });
+
+    it('should pass isSubscribed=false when the user has unsubscribed', async () => {
+      await createWelcomeEmailLog(
+        { email: 'x@y.com', isSubscribed: false, waitlistId: 'w' } as any,
+        { senderEmail: 's', senderName: 'S', subject: 'W', template: 'T', type: 'waitlist_welcome_email' } as any,
+      );
+      expect(mockQueueEmail).toHaveBeenCalledWith(expect.objectContaining({ isSubscribed: false }));
     });
   });
 });

--- a/functions/src/__tests__/handleUnsubscribe.spec.ts
+++ b/functions/src/__tests__/handleUnsubscribe.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the one-click unsubscribe HTTP function
+ * (functions/src/email-core/handleUnsubscribe.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../constant', () => ({
+  constant: { isProduction: false, live_url: 'https://app.example.com/', local_url: 'http://localhost:5173/' },
+}));
+
+const {
+  mockSettingsGet,
+  mockEmailLogsGet,
+  mockSuppressionSet,
+  mockWaitlistedGet,
+  mockCollectionGroupGet,
+  waitlistUpdate,
+} = vi.hoisted(() => ({
+  mockSettingsGet: vi.fn(),
+  mockEmailLogsGet: vi.fn(),
+  mockSuppressionSet: vi.fn().mockResolvedValue(undefined),
+  mockWaitlistedGet: vi.fn(),
+  mockCollectionGroupGet: vi.fn(),
+  waitlistUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../init', () => ({
+  db: {
+    collection: vi.fn((name: string) => {
+      if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
+      if (name === 'EmailLogs') {
+        return { where: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ get: mockEmailLogsGet }) }) };
+      }
+      if (name === 'Suppression') return { doc: vi.fn().mockReturnValue({ set: mockSuppressionSet }) };
+      if (name === 'WaitlistedUsers') {
+        return { where: vi.fn().mockReturnValue({ get: mockWaitlistedGet }) };
+      }
+      return {};
+    }),
+    collectionGroup: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ get: mockCollectionGroupGet }) }),
+  },
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  Timestamp: { now: vi.fn(() => ({ seconds: 0, nanoseconds: 0 })) },
+}));
+
+vi.mock('firebase-functions/v2', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+  onRequest: vi.fn((handler: any) => handler),
+}));
+
+import { handleUnsubscribe } from '../email-core/handleUnsubscribe.js';
+import { computeEmailHash, buildUnsubscribeToken } from '../email-core/unsubscribeToken.js';
+
+const handler = handleUnsubscribe as unknown as (req: any, res: any) => Promise<void>;
+
+const SECRET = 'unsub-secret';
+const EMAIL = 'user@example.com';
+const HASH = computeEmailHash(EMAIL);
+const TOKEN = buildUnsubscribeToken(HASH, SECRET);
+
+function makeRes() {
+  const res: any = {
+    statusCode: 200,
+    body: '',
+    status: vi.fn(function (this: any, code: number) { res.statusCode = code; return res; }),
+    send: vi.fn(function (this: any, body: string) { res.body = body; return res; }),
+  };
+  return res;
+}
+
+describe('handleUnsubscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsGet.mockResolvedValue({ data: () => ({ unsubscribeSecret: SECRET }) });
+    mockEmailLogsGet.mockResolvedValue({ empty: false, docs: [{ data: () => ({ toEmail: EMAIL }) }] });
+    mockWaitlistedGet.mockResolvedValue({ docs: [{ ref: { update: waitlistUpdate } }] });
+    mockCollectionGroupGet.mockResolvedValue({ docs: [] });
+    mockSuppressionSet.mockResolvedValue(undefined);
+  });
+
+  it('GET with a valid token unsubscribes and returns the success page', async () => {
+    const res = makeRes();
+    await handler({ method: 'GET', query: { e: HASH, t: TOKEN }, body: {} }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('Successfully Unsubscribed');
+
+    // Suppression doc written with the recovered email + reason.
+    expect(mockSuppressionSet).toHaveBeenCalledWith(
+      expect.objectContaining({ email: EMAIL, emailHash: HASH, reason: 'unsubscribe' }),
+      { merge: true },
+    );
+    // Legacy waitlist flag flipped.
+    expect(waitlistUpdate).toHaveBeenCalledWith({ isSubscribed: false });
+  });
+
+  it('GET with an invalid token returns 400 and does NOT suppress', async () => {
+    const res = makeRes();
+    await handler({ method: 'GET', query: { e: HASH, t: 'bad-token' }, body: {} }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('Invalid Unsubscribe Link');
+    expect(mockSuppressionSet).not.toHaveBeenCalled();
+  });
+
+  it('POST one-click with a valid token returns 200 plain (no page)', async () => {
+    const res = makeRes();
+    await handler({ method: 'POST', query: {}, body: { e: HASH, t: TOKEN } }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('unsubscribed');
+    expect(mockSuppressionSet).toHaveBeenCalled();
+  });
+
+  it('POST with an invalid token returns 400 plain', async () => {
+    const res = makeRes();
+    await handler({ method: 'POST', query: {}, body: { e: HASH, t: 'nope' } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe('invalid token');
+  });
+
+  it('still writes suppression when the email cannot be recovered', async () => {
+    mockEmailLogsGet.mockResolvedValue({ empty: true, docs: [] });
+    const res = makeRes();
+    await handler({ method: 'GET', query: { e: HASH, t: TOKEN }, body: {} }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockSuppressionSet).toHaveBeenCalledWith(
+      expect.objectContaining({ email: '', emailHash: HASH, reason: 'unsubscribe' }),
+      { merge: true },
+    );
+    // No email → no waitlist flip attempted.
+    expect(waitlistUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when no unsubscribeSecret is configured', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => ({}) });
+    const res = makeRes();
+    await handler({ method: 'GET', query: { e: HASH, t: TOKEN }, body: {} }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockSuppressionSet).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/__tests__/mailConfigAndAnalytics.spec.ts
+++ b/functions/src/__tests__/mailConfigAndAnalytics.spec.ts
@@ -184,7 +184,8 @@ describe('sendMail — email counter integration', () => {
       path.resolve(__dirname, '../mail-config/mailConfig.ts'),
       'utf-8'
     );
-    expect(fileContent).toContain("import { incrementSendCount } from './emailCounter.js'");
+    // Import now also pulls in quota helpers for universal rate-limit enforcement.
+    expect(fileContent).toMatch(/import \{[^}]*incrementSendCount[^}]*\} from '\.\/emailCounter\.js'/);
   });
 
   it('should call incrementSendCount after successful email send', async () => {

--- a/functions/src/__tests__/noDirectEmailLogWrites.spec.ts
+++ b/functions/src/__tests__/noDirectEmailLogWrites.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * E5 kill-switch audit (source scan).
+ *
+ * After Phase 1, the queueEmail() chokepoint in `email-core/` is the ONLY place
+ * allowed to CREATE `EmailLogs` documents. This test walks every non-test source
+ * file under functions/src and fails if any file outside `email-core/` creates an
+ * EmailLogs doc via `.add(...)` or `.doc(...).set(...)`.
+ *
+ * (Updates to existing docs — `.doc(id).update(...)` in sendMail / webhook /
+ * open-tracking — are allowed; they modify, they don't queue new sends.)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SRC_ROOT = resolve(__dirname, '..');
+
+/** Recursively collect .ts files, excluding tests and the sanctioned email-core module. */
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules' || entry === 'email-core') continue;
+      collectSourceFiles(full, acc);
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts') && !entry.endsWith('.test.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Matches EmailLogs *creation*: `collection('EmailLogs').add(` and
+// `collection('EmailLogs').doc(...).set(`. Tolerant of whitespace/newlines.
+const ADD_PATTERN = /collection\(\s*['"]EmailLogs['"]\s*\)\s*\.add\s*\(/;
+const DOC_SET_PATTERN = /collection\(\s*['"]EmailLogs['"]\s*\)\s*\.doc\([^)]*\)\s*\.set\s*\(/;
+
+describe('E5: no direct EmailLogs writes outside email-core', () => {
+  const files = collectSourceFiles(SRC_ROOT);
+
+  it('finds source files to scan', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('no file outside email-core creates an EmailLogs doc', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const content = readFileSync(file, 'utf-8');
+      if (ADD_PATTERN.test(content) || DOC_SET_PATTERN.test(content)) {
+        offenders.push(relative(SRC_ROOT, file));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the queueEmail chokepoint IS the writer (sanity check on the scan)', () => {
+    const queueEmailSrc = readFileSync(resolve(SRC_ROOT, 'email-core/queueEmail.ts'), 'utf-8');
+    expect(ADD_PATTERN.test(queueEmailSrc)).toBe(true);
+  });
+});

--- a/functions/src/__tests__/onEmailLogCreateGuard.spec.ts
+++ b/functions/src/__tests__/onEmailLogCreateGuard.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests that onEmailLogCreate only sends `pending` docs and never delivers the
+ * blocked docs that queueEmail() writes (skipped / suppressed / etc.).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSendMail } = vi.hoisted(() => ({ mockSendMail: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('../mail-config/mailConfig', () => ({ sendMail: mockSendMail }));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentCreated: vi.fn((_path: string, handler: any) => handler),
+}));
+
+import { onEmailLogCreate } from '../email-log/createEmailLog.js';
+
+const handler = onEmailLogCreate as unknown as (event: any) => Promise<void>;
+
+function event(data: any) {
+  return { data: { data: () => data }, params: { EmailLogsId: 'log-1' } };
+}
+
+describe('onEmailLogCreate status guard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends when status is pending', async () => {
+    await handler(event({ toEmail: 'a@b.com', status: 'pending' }));
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+    expect(mockSendMail).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending' }), 'log-1');
+  });
+
+  it('sends when status is absent (legacy/defensive)', async () => {
+    await handler(event({ toEmail: 'a@b.com' }));
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['skipped', 'suppressed', 'deferred', 'retrying', 'success', 'failed'])(
+    'does NOT send when status is %s',
+    async (status) => {
+      await handler(event({ toEmail: 'a@b.com', status }));
+      expect(mockSendMail).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does nothing when there is no data', async () => {
+    await handler({ data: undefined, params: { EmailLogsId: 'log-1' } });
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/__tests__/queueEmail.spec.ts
+++ b/functions/src/__tests__/queueEmail.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the queueEmail() chokepoint (functions/src/email-core/queueEmail.ts).
+ *
+ * Verifies the gating order and that every blocked send writes an auditable
+ * EmailLogs doc with the correct status + skipReason (never silently dropped).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAdd, mockSettingsGet, mockSuppressionGet } = vi.hoisted(() => ({
+  mockAdd: vi.fn().mockResolvedValue({ id: 'log-1' }),
+  mockSettingsGet: vi.fn(),
+  mockSuppressionGet: vi.fn(),
+}));
+
+vi.mock('../init', () => ({
+  db: {
+    collection: vi.fn((name: string) => {
+      if (name === 'Settings') {
+        return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
+      }
+      if (name === 'Suppression') {
+        return { doc: vi.fn().mockReturnValue({ get: mockSuppressionGet }) };
+      }
+      if (name === 'EmailLogs') {
+        return { add: mockAdd };
+      }
+      return {};
+    }),
+  },
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  Timestamp: {
+    now: vi.fn(() => ({ seconds: 0, nanoseconds: 0 })),
+    fromMillis: vi.fn((ms: number) => ({ seconds: Math.floor(ms / 1000), nanoseconds: 0 })),
+  },
+}));
+
+import { queueEmail } from '../email-core/queueEmail.js';
+
+/** Fully-enabled settings with all feature toggles on. */
+function enabledSettings(overrides: Record<string, any> = {}) {
+  return {
+    isEnabled: true,
+    activeProvider: 'smtp',
+    features: {
+      waitlistEmails: true,
+      authEmails: true,
+      paymentEmails: true,
+      notificationEmails: true,
+      broadcasts: true,
+      drips: true,
+      adminAlerts: true,
+    },
+    ...overrides,
+  };
+}
+
+const baseParams = {
+  source: 'waitlist' as const,
+  category: 'transactional' as const,
+  toEmail: 'user@example.com',
+  toName: 'User',
+  senderEmail: 's@site.com',
+  senderName: 'Site',
+  subject: 'Hi',
+  template: '<p>hi</p>',
+  type: 'waitlist_verify_otp_email',
+};
+
+function lastAddArg() {
+  return mockAdd.mock.calls[mockAdd.mock.calls.length - 1][0];
+}
+
+describe('queueEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdd.mockResolvedValue({ id: 'log-1' });
+    mockSuppressionGet.mockResolvedValue({ exists: false, data: () => undefined });
+  });
+
+  it('writes a pending log when all gates pass', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+
+    const res = await queueEmail(baseParams);
+
+    expect(res.status).toBe('pending');
+    expect(res.id).toBe('log-1');
+    const doc = lastAddArg();
+    expect(doc.status).toBe('pending');
+    expect(doc.category).toBe('transactional');
+    expect(doc.source).toBe('waitlist');
+    expect(doc.attempts).toBe(0);
+    expect(doc.maxAttempts).toBe(3);
+    expect(doc.emailHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(doc.skipReason).toBeUndefined();
+  });
+
+  it('gate 1: master kill-switch off ⇒ skipped/email_disabled', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings({ isEnabled: false }) });
+
+    const res = await queueEmail(baseParams);
+
+    expect(res.status).toBe('skipped');
+    expect(res.skipReason).toBe('email_disabled');
+    expect(lastAddArg().status).toBe('skipped');
+    expect(lastAddArg().skipReason).toBe('email_disabled');
+  });
+
+  it('gate 1: missing provider ⇒ skipped/email_disabled', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings({ activeProvider: undefined }) });
+
+    const res = await queueEmail(baseParams);
+
+    expect(res.skipReason).toBe('email_disabled');
+  });
+
+  it('gate 2: feature toggle off ⇒ skipped/feature_disabled', async () => {
+    mockSettingsGet.mockResolvedValue({
+      data: () => enabledSettings({ features: { waitlistEmails: false } }),
+    });
+
+    const res = await queueEmail(baseParams);
+
+    expect(res.status).toBe('skipped');
+    expect(res.skipReason).toBe('feature_disabled');
+  });
+
+  it('gate 2: each source maps to its own feature key', async () => {
+    mockSettingsGet.mockResolvedValue({
+      data: () => enabledSettings({ features: { paymentEmails: false, waitlistEmails: true } }),
+    });
+
+    // payment source is gated by paymentEmails=false
+    const blocked = await queueEmail({ ...baseParams, source: 'payment', type: 'payment_succeeded_email' });
+    expect(blocked.skipReason).toBe('feature_disabled');
+
+    // waitlist source still passes (waitlistEmails=true)
+    const ok = await queueEmail(baseParams);
+    expect(ok.status).toBe('pending');
+  });
+
+  it('gate 2: event/test sources have no feature gate', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings({ features: {} }) });
+
+    const res = await queueEmail({ ...baseParams, source: 'test', type: 'test' });
+    expect(res.status).toBe('pending');
+  });
+
+  it('gate 3: templateIsActive=false ⇒ skipped/template_inactive', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+
+    const res = await queueEmail({ ...baseParams, templateIsActive: false });
+
+    expect(res.status).toBe('skipped');
+    expect(res.skipReason).toBe('template_inactive');
+  });
+
+  it('gate 4: marketing + isSubscribed=false ⇒ skipped/unsubscribed', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+
+    const res = await queueEmail({
+      ...baseParams,
+      category: 'marketing',
+      type: 'waitlist_welcome_email',
+      isSubscribed: false,
+    });
+
+    expect(res.status).toBe('skipped');
+    expect(res.skipReason).toBe('unsubscribed');
+  });
+
+  it('gate 4: transactional ignores consent', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+
+    const res = await queueEmail({ ...baseParams, category: 'transactional', isSubscribed: false });
+
+    expect(res.status).toBe('pending');
+  });
+
+  it('gate 5: marketing blocked by ANY suppression reason ⇒ suppressed', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+    mockSuppressionGet.mockResolvedValue({ exists: true, data: () => ({ reason: 'unsubscribe' }) });
+
+    const res = await queueEmail({
+      ...baseParams,
+      category: 'marketing',
+      type: 'waitlist_welcome_email',
+      isSubscribed: true,
+    });
+
+    expect(res.status).toBe('suppressed');
+    expect(res.skipReason).toBe('suppressed');
+  });
+
+  it('gate 5: transactional blocked only by bounce/complaint', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings() });
+
+    // soft reason (unsubscribe) does NOT block transactional
+    mockSuppressionGet.mockResolvedValue({ exists: true, data: () => ({ reason: 'unsubscribe' }) });
+    const ok = await queueEmail({ ...baseParams, category: 'transactional' });
+    expect(ok.status).toBe('pending');
+
+    // hard bounce DOES block transactional
+    mockSuppressionGet.mockResolvedValue({ exists: true, data: () => ({ reason: 'bounce' }) });
+    const blocked = await queueEmail({ ...baseParams, category: 'transactional' });
+    expect(blocked.status).toBe('suppressed');
+  });
+
+  it('uses provided emailSettings without reading Settings', async () => {
+    const res = await queueEmail({ ...baseParams, emailSettings: enabledSettings() as any });
+
+    expect(res.status).toBe('pending');
+    expect(mockSettingsGet).not.toHaveBeenCalled();
+  });
+
+  it('resolves bcc from settings when not provided', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => enabledSettings({ bccEmail: 'admin@site.com' }) });
+
+    await queueEmail(baseParams);
+
+    expect(lastAddArg().bcc).toBe('admin@site.com');
+  });
+});

--- a/functions/src/__tests__/retryPendingEmails.spec.ts
+++ b/functions/src/__tests__/retryPendingEmails.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the retry scheduler (functions/src/email-core/retryPendingEmails.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSendMail, statusQueries, mockGetFactory } = vi.hoisted(() => {
+  const statusQueries: Record<string, any[]> = { retrying: [], deferred: [] };
+  return {
+    mockSendMail: vi.fn().mockResolvedValue(undefined),
+    statusQueries,
+    mockGetFactory: vi.fn(),
+  };
+});
+
+vi.mock('../mail-config/mailConfig', () => ({
+  sendMail: mockSendMail,
+}));
+
+vi.mock('../init', () => ({
+  db: {
+    collection: vi.fn(() => {
+      // Chain: .where('status','==',X).where('nextAttemptAt','<=',now).limit(n).get()
+      let capturedStatus = '';
+      const chain: any = {
+        where: vi.fn((field: string, _op: string, value: any) => {
+          if (field === 'status') capturedStatus = value;
+          return chain;
+        }),
+        limit: vi.fn(() => chain),
+        get: vi.fn(async () => ({ docs: statusQueries[capturedStatus] || [] })),
+      };
+      return chain;
+    }),
+  },
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  Timestamp: { now: vi.fn(() => ({ seconds: 100, nanoseconds: 0 })) },
+}));
+
+vi.mock('firebase-functions/v2', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: vi.fn((_opts: any, handler: any) => handler),
+}));
+
+import { retryPendingEmails } from '../email-core/retryPendingEmails.js';
+
+const handler = retryPendingEmails as unknown as () => Promise<void>;
+
+function doc(id: string) {
+  return { id, data: () => ({ toEmail: `${id}@x.com`, status: 'retrying' }) };
+}
+
+describe('retryPendingEmails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    statusQueries.retrying = [];
+    statusQueries.deferred = [];
+    mockSendMail.mockResolvedValue(undefined);
+  });
+
+  it('re-runs sendMail for each due retrying + deferred doc', async () => {
+    statusQueries.retrying = [doc('a'), doc('b')];
+    statusQueries.deferred = [doc('c')];
+
+    await handler();
+
+    expect(mockSendMail).toHaveBeenCalledTimes(3);
+    const ids = mockSendMail.mock.calls.map((c) => c[1]);
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does nothing when no docs are due', async () => {
+    await handler();
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it('continues past a sendMail failure', async () => {
+    statusQueries.retrying = [doc('a'), doc('b')];
+    mockSendMail.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(handler()).resolves.toBeUndefined();
+    expect(mockSendMail).toHaveBeenCalledTimes(2);
+  });
+
+  it('schedules every 5 minutes (source check)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(dir, '../email-core/retryPendingEmails.ts'), 'utf-8');
+    expect(src).toContain("schedule: 'every 5 minutes'");
+    expect(src).toContain("from 'firebase-functions/v2/scheduler'");
+  });
+});

--- a/functions/src/__tests__/sendMailHardening.spec.ts
+++ b/functions/src/__tests__/sendMailHardening.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Behavioural tests for the Phase 1 sendMail() hardening
+ * (functions/src/mail-config/mailConfig.ts):
+ *   - belt-and-braces kill-switch (skipped/email_disabled)
+ *   - universal quota enforcement (deferred/quota)
+ *   - retry with backoff (retrying → failed at maxAttempts), attempts counter
+ *   - List-Unsubscribe headers on marketing sends only
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockSettingsGet,
+  mockLogUpdate,
+  mockCheckQuota,
+  mockResolveLimits,
+  mockIncrement,
+  mockTransportSend,
+} = vi.hoisted(() => ({
+  mockSettingsGet: vi.fn(),
+  mockLogUpdate: vi.fn().mockResolvedValue(undefined),
+  mockCheckQuota: vi.fn().mockResolvedValue({ ok: true, dailyCount: 0, hourlyCount: 0 }),
+  mockResolveLimits: vi.fn().mockReturnValue({ perSecond: 1 }),
+  mockIncrement: vi.fn().mockResolvedValue(undefined),
+  mockTransportSend: vi.fn().mockResolvedValue({ messageId: 'mid-1' }),
+}));
+
+vi.mock('../init', () => ({
+  db: {
+    collection: vi.fn((name: string) => {
+      if (name === 'Settings') return { doc: vi.fn().mockReturnValue({ get: mockSettingsGet }) };
+      if (name === 'EmailLogs') return { doc: vi.fn().mockReturnValue({ update: mockLogUpdate }) };
+      return {};
+    }),
+  },
+}));
+
+vi.mock('../constant', () => ({
+  constant: { isProduction: false, live_url: 'https://app.example.com/', local_url: 'http://localhost:5173/', TRACKING_PIXEL_URL: '' },
+}));
+
+vi.mock('../mail-config/emailCounter', () => ({
+  checkQuota: mockCheckQuota,
+  resolveProviderLimits: mockResolveLimits,
+  incrementSendCount: mockIncrement,
+}));
+
+vi.mock('../shared/site-settings', () => ({
+  getMiscSettings: vi.fn().mockResolvedValue({ showPoweredBy: false }),
+}));
+
+vi.mock('../shared/html-document', () => ({ POWERED_BY_EMAIL_HTML: '<!--pb-->' }));
+
+vi.mock('nodemailer', () => ({
+  default: { createTransport: vi.fn(() => ({ sendMail: mockTransportSend })) },
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  Timestamp: {
+    now: vi.fn(() => ({ seconds: 100, nanoseconds: 0 })),
+    fromMillis: vi.fn((ms: number) => ({ seconds: Math.floor(ms / 1000), nanoseconds: 0, __ms: ms })),
+  },
+}));
+
+import { sendMail } from '../mail-config/mailConfig.js';
+
+function smtpSettings(overrides: Record<string, any> = {}) {
+  return {
+    isEnabled: true,
+    activeProvider: 'smtp',
+    smtp: { host: 'smtp.test', port: 587, user: 'u', password: 'p' },
+    unsubscribeSecret: 'sekret',
+    ...overrides,
+  };
+}
+
+function baseLog(overrides: Record<string, any> = {}) {
+  return {
+    senderEmail: 's@site.com',
+    senderName: 'Site',
+    toName: 'User',
+    toEmail: 'user@example.com',
+    subject: 'Hi',
+    template: '<p>hi</p>',
+    text: 't',
+    type: 'x',
+    category: 'transactional',
+    attempts: 0,
+    maxAttempts: 3,
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+const lastUpdate = () => mockLogUpdate.mock.calls[mockLogUpdate.mock.calls.length - 1][0];
+
+describe('sendMail hardening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckQuota.mockResolvedValue({ ok: true, dailyCount: 0, hourlyCount: 0 });
+    mockResolveLimits.mockReturnValue({ perSecond: 1 });
+    mockTransportSend.mockResolvedValue({ messageId: 'mid-1' });
+  });
+
+  it('kill-switch off ⇒ marks skipped/email_disabled and never sends', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings({ isEnabled: false }) });
+
+    await sendMail(baseLog() as any, 'log-1');
+
+    expect(mockTransportSend).not.toHaveBeenCalled();
+    expect(lastUpdate()).toMatchObject({ status: 'skipped', skipReason: 'email_disabled' });
+  });
+
+  it('quota exhausted ⇒ deferred/quota with nextAttemptAt, no send', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+    mockCheckQuota.mockResolvedValue({ ok: false, dailyCount: 999, hourlyCount: 0 });
+
+    await sendMail(baseLog() as any, 'log-1');
+
+    expect(mockTransportSend).not.toHaveBeenCalled();
+    const upd = lastUpdate();
+    expect(upd.status).toBe('deferred');
+    expect(upd.skipReason).toBe('quota');
+    expect(upd.nextAttemptAt).toBeDefined();
+  });
+
+  it('successful send ⇒ status success, attempts incremented to 1', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+
+    await sendMail(baseLog() as any, 'log-1');
+
+    expect(mockTransportSend).toHaveBeenCalledTimes(1);
+    const upd = lastUpdate();
+    expect(upd.status).toBe('success');
+    expect(upd.attempts).toBe(1);
+    expect(upd.messageId).toBe('mid-1');
+    expect(mockIncrement).toHaveBeenCalledWith('smtp');
+  });
+
+  it('transient failure below maxAttempts ⇒ retrying with backoff', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+    mockTransportSend.mockRejectedValue(new Error('smtp down'));
+
+    await sendMail(baseLog({ attempts: 0 }) as any, 'log-1');
+
+    const upd = lastUpdate();
+    expect(upd.status).toBe('retrying');
+    expect(upd.attempts).toBe(1);
+    expect(upd.nextAttemptAt).toBeDefined();
+    expect(upd.errorMessage).toContain('smtp down');
+  });
+
+  it('transient failure at final attempt ⇒ failed, no nextAttemptAt', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+    mockTransportSend.mockRejectedValue(new Error('still down'));
+
+    // attempts=2, maxAttempts=3 ⇒ this attempt is the 3rd (final)
+    await sendMail(baseLog({ attempts: 2, maxAttempts: 3 }) as any, 'log-1');
+
+    const upd = lastUpdate();
+    expect(upd.status).toBe('failed');
+    expect(upd.attempts).toBe(3);
+    expect(upd.nextAttemptAt).toBeUndefined();
+  });
+
+  it('marketing send carries List-Unsubscribe headers', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+
+    await sendMail(baseLog({ category: 'marketing' }) as any, 'log-1');
+
+    const sendArg = mockTransportSend.mock.calls[0][0];
+    expect(sendArg.headers['List-Unsubscribe']).toMatch(/^<https?:\/\/.+\/unsubscribe\?e=.+&t=.+>$/);
+    expect(sendArg.headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
+  });
+
+  it('transactional send has no List-Unsubscribe headers', async () => {
+    mockSettingsGet.mockResolvedValue({ data: () => smtpSettings() });
+
+    await sendMail(baseLog({ category: 'transactional' }) as any, 'log-1');
+
+    const sendArg = mockTransportSend.mock.calls[0][0];
+    expect(sendArg.headers['List-Unsubscribe']).toBeUndefined();
+  });
+});

--- a/functions/src/__tests__/unsubscribeToken.spec.ts
+++ b/functions/src/__tests__/unsubscribeToken.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the HMAC unsubscribe-token helpers
+ * (functions/src/email-core/unsubscribeToken.ts).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../constant', () => ({
+  constant: { isProduction: false, live_url: 'https://app.example.com/', local_url: 'http://localhost:5173/' },
+}));
+
+import {
+  computeEmailHash,
+  buildUnsubscribeToken,
+  verifyUnsubscribeToken,
+  buildUnsubscribeUrl,
+} from '../email-core/unsubscribeToken.js';
+
+describe('unsubscribeToken', () => {
+  describe('computeEmailHash', () => {
+    it('is sha256 of the normalised email (lowercase + trim)', () => {
+      const a = computeEmailHash('User@Example.com');
+      const b = computeEmailHash('  user@example.com ');
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('differs for different addresses', () => {
+      expect(computeEmailHash('a@x.com')).not.toBe(computeEmailHash('b@x.com'));
+    });
+  });
+
+  describe('buildUnsubscribeToken / verifyUnsubscribeToken', () => {
+    const hash = computeEmailHash('user@example.com');
+    const secret = 'super-secret';
+
+    it('a freshly minted token validates', () => {
+      const token = buildUnsubscribeToken(hash, secret);
+      expect(verifyUnsubscribeToken(hash, token, secret)).toBe(true);
+    });
+
+    it('rejects a tampered token', () => {
+      const token = buildUnsubscribeToken(hash, secret);
+      expect(verifyUnsubscribeToken(hash, token + 'ff', secret)).toBe(false);
+      expect(verifyUnsubscribeToken(hash, token.slice(0, -2) + '00', secret)).toBe(false);
+    });
+
+    it('rejects a token minted with a different secret', () => {
+      const token = buildUnsubscribeToken(hash, 'other-secret');
+      expect(verifyUnsubscribeToken(hash, token, secret)).toBe(false);
+    });
+
+    it('rejects a token bound to a different emailHash', () => {
+      const token = buildUnsubscribeToken(computeEmailHash('someone@else.com'), secret);
+      expect(verifyUnsubscribeToken(hash, token, secret)).toBe(false);
+    });
+
+    it('rejects when any argument is empty', () => {
+      const token = buildUnsubscribeToken(hash, secret);
+      expect(verifyUnsubscribeToken('', token, secret)).toBe(false);
+      expect(verifyUnsubscribeToken(hash, '', secret)).toBe(false);
+      expect(verifyUnsubscribeToken(hash, token, '')).toBe(false);
+    });
+  });
+
+  describe('buildUnsubscribeUrl', () => {
+    it('builds an e/t URL that round-trips through verify (fixes empty-userId bug)', () => {
+      const url = buildUnsubscribeUrl('user@example.com', 'super-secret');
+      expect(url).toContain('unsubscribe?e=');
+      expect(url).toContain('&t=');
+      // The link must NOT contain the old empty-userId form.
+      expect(url).not.toContain('userId=');
+
+      const u = new URL(url);
+      const e = u.searchParams.get('e')!;
+      const t = u.searchParams.get('t')!;
+      expect(e).toBe(computeEmailHash('user@example.com'));
+      expect(verifyUnsubscribeToken(e, t, 'super-secret')).toBe(true);
+    });
+
+    it('returns empty string when no secret is configured', () => {
+      expect(buildUnsubscribeUrl('user@example.com', undefined)).toBe('');
+      expect(buildUnsubscribeUrl('user@example.com', '')).toBe('');
+    });
+  });
+});

--- a/functions/src/dodo-payments/paymentEmailHelper.ts
+++ b/functions/src/dodo-payments/paymentEmailHelper.ts
@@ -1,7 +1,7 @@
-import { Timestamp } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions/v2';
 import { db } from '../init.js';
-import { EmailLogData, EmailTemplateData } from '../types.js';
+import { EmailTemplateData } from '../types.js';
+import { queueEmail } from '../email-core/queueEmail.js';
 import { PaymentEmailType } from './types.js';
 
 /**
@@ -46,45 +46,32 @@ export async function sendPaymentEmail(
   }
 
   const template = snap.docs[0].data() as EmailTemplateData & { isActive?: boolean };
-  if (template.isActive === false) {
-    logger.info(`Payment email template ${type} is disabled; skipping.`);
-    return;
-  }
-
-  // BCC from email settings (mirrors the waitlist email helpers).
-  let bccEmail = '';
-  try {
-    const settingsDoc = await db.collection('Settings').doc('email').get();
-    if (settingsDoc.exists) {
-      bccEmail = settingsDoc.data()?.['bccEmail'] || '';
-    }
-  } catch (e) {
-    logger.error('Error fetching email settings for BCC', e);
-  }
 
   const toName = recipient.name || recipient.email.split('@')[0];
 
-  const emailObj: EmailLogData = {
+  // Route through the queueEmail() chokepoint — it enforces the kill-switch,
+  // the paymentEmails feature toggle, template-active state, and suppression,
+  // and resolves BCC from settings. Payment email is transactional.
+  await queueEmail({
+    source: 'payment',
+    category: 'transactional',
+    toEmail: recipient.email,
+    toName,
     senderEmail: template.senderEmail,
     senderName: template.senderName,
-    toName,
-    name: toName,
-    toEmail: recipient.email,
     subject: template.subject,
     template: template.template,
     text: template.previewText || '',
-    bcc: bccEmail,
     type,
-    createdAt: Timestamp.now(),
-    // Tag data
-    currency: vars.currency || '',
-    price: vars.amount !== undefined ? String(vars.amount) : '',
-    paymentStatus: vars.status || '',
-    subscriptionPlan: vars.plan || '',
-    renewalDate: vars.renewalDate || '',
-    trialEndsAt: vars.trialEndsAt || '',
-  };
-
-  await db.collection('EmailLogs').add(emailObj);
+    templateIsActive: template.isActive !== false,
+    data: {
+      currency: vars.currency || '',
+      price: vars.amount !== undefined ? String(vars.amount) : '',
+      paymentStatus: vars.status || '',
+      subscriptionPlan: vars.plan || '',
+      renewalDate: vars.renewalDate || '',
+      trialEndsAt: vars.trialEndsAt || '',
+    },
+  });
   logger.info(`Enqueued payment email ${type} to ${recipient.email}`);
 }

--- a/functions/src/email-core/handleUnsubscribe.ts
+++ b/functions/src/email-core/handleUnsubscribe.ts
@@ -1,0 +1,169 @@
+import { onRequest } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { Timestamp } from 'firebase-admin/firestore';
+import { db } from '../init.js';
+import type { EmailSettings } from '../types.js';
+import { verifyUnsubscribeToken } from './unsubscribeToken.js';
+
+/**
+ * One-click unsubscribe endpoint: `/unsubscribe?e={emailHash}&t={hmac}`.
+ *
+ * - GET  → validates the token, unsubscribes the recipient, returns an HTML
+ *          confirmation page (the link a human clicks in the email footer).
+ * - POST → RFC 8058 one-click (`List-Unsubscribe-Post: List-Unsubscribe=One-Click`);
+ *          same processing, returns 200 with no page.
+ *
+ * The token is an HMAC of the emailHash under `Settings/email.unsubscribeSecret`,
+ * so links can't be forged and work for non-user contacts too (no Firestore
+ * access from the client). This replaces the old empty-userId unsubscribe link.
+ */
+export const handleUnsubscribe = onRequest(async (req, res) => {
+  const emailHash = String(req.query['e'] || (req.body && req.body.e) || '');
+  const token = String(req.query['t'] || (req.body && req.body.t) || '');
+  const isPost = req.method === 'POST';
+
+  const settings = await readEmailSettings();
+  const secret = settings?.unsubscribeSecret;
+
+  if (!verifyUnsubscribeToken(emailHash, token, secret || '')) {
+    logger.warn('handleUnsubscribe: invalid or unverifiable token');
+    if (isPost) {
+      res.status(400).send('invalid token');
+      return;
+    }
+    res.status(400).send(renderPage('invalid'));
+    return;
+  }
+
+  try {
+    await unsubscribeByEmailHash(emailHash);
+  } catch (err) {
+    logger.error('handleUnsubscribe: failed to process unsubscribe', err);
+    if (isPost) {
+      res.status(500).send('error');
+      return;
+    }
+    res.status(500).send(renderPage('error'));
+    return;
+  }
+
+  if (isPost) {
+    res.status(200).send('unsubscribed');
+    return;
+  }
+  res.status(200).send(renderPage('success'));
+});
+
+/**
+ * Suppress future email for a recipient and flip legacy `isSubscribed` flags.
+ * Idempotent: safe to call repeatedly.
+ */
+async function unsubscribeByEmailHash(emailHash: string): Promise<void> {
+  // Recover the raw email from the recipient's most recent EmailLogs doc.
+  // Used to populate the Suppression record and to locate waitlist docs.
+  let email = '';
+  try {
+    const logSnap = await db
+      .collection('EmailLogs')
+      .where('emailHash', '==', emailHash)
+      .limit(1)
+      .get();
+    if (!logSnap.empty) {
+      email = (logSnap.docs[0].data()['toEmail'] as string) || '';
+    }
+  } catch (err) {
+    logger.warn('handleUnsubscribe: could not recover email from EmailLogs', err);
+  }
+
+  // Durable enforcement: a Suppression doc keyed by emailHash is what
+  // queueEmail checks on every future send.
+  await db.collection('Suppression').doc(emailHash).set(
+    {
+      email,
+      emailHash,
+      reason: 'unsubscribe',
+      at: Timestamp.now(),
+    },
+    { merge: true },
+  );
+
+  // Best-effort: keep legacy waitlist readers in sync (isSubscribed:false).
+  if (email) {
+    try {
+      const snap = await db
+        .collection('WaitlistedUsers')
+        .where('email', '==', email)
+        .get();
+      await Promise.all(snap.docs.map((d) => d.ref.update({ isSubscribed: false })));
+    } catch (err) {
+      logger.warn('handleUnsubscribe: could not update WaitlistedUsers', err);
+    }
+
+    try {
+      const subSnap = await db
+        .collectionGroup('users')
+        .where('email', '==', email)
+        .get();
+      await Promise.all(subSnap.docs.map((d) => d.ref.update({ isSubscribed: false })));
+    } catch (err) {
+      logger.warn('handleUnsubscribe: could not update waitlist subcollection users', err);
+    }
+  }
+}
+
+async function readEmailSettings(): Promise<EmailSettings | undefined> {
+  try {
+    const snap = await db.collection('Settings').doc('email').get();
+    return snap.data() as EmailSettings | undefined;
+  } catch (err) {
+    logger.error('handleUnsubscribe: failed to read Settings/email', err);
+    return undefined;
+  }
+}
+
+function renderPage(kind: 'success' | 'invalid' | 'error'): string {
+  const content: Record<typeof kind, { icon: string; title: string; body: string }> = {
+    success: {
+      icon: '✓',
+      title: 'Successfully Unsubscribed',
+      body: 'You have been removed from our mailing list. You may still receive essential transactional messages (such as receipts).',
+    },
+    invalid: {
+      icon: '❌',
+      title: 'Invalid Unsubscribe Link',
+      body: 'This unsubscribe link appears to be invalid or expired.',
+    },
+    error: {
+      icon: '⚠',
+      title: 'Something went wrong',
+      body: 'We were unable to process your unsubscribe request. Please try again later.',
+    },
+  };
+  const c = content[kind];
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>${c.title}</title>
+<style>
+  body { margin:0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: linear-gradient(135deg, #f6f8fb 0%, #eef1f5 100%); min-height:100vh;
+    display:flex; align-items:center; justify-content:center; padding:20px; }
+  .card { background:#fff; border-radius:16px; padding:50px 40px; text-align:center;
+    max-width:500px; width:100%; box-shadow:0 4px 20px rgba(0,0,0,.08); }
+  .icon { font-size:4rem; margin-bottom:20px; }
+  h1 { font-size:1.5rem; font-weight:700; margin:0 0 15px; color:#1a202c; }
+  p { color:#64748b; margin:0; line-height:1.5; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">${c.icon}</div>
+    <h1>${c.title}</h1>
+    <p>${c.body}</p>
+  </div>
+</body>
+</html>`;
+}

--- a/functions/src/email-core/queueEmail.ts
+++ b/functions/src/email-core/queueEmail.ts
@@ -1,0 +1,179 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import { db } from '../init.js';
+import type {
+  EmailCategory,
+  EmailSource,
+  EmailSkipReason,
+  EmailSettings,
+} from '../types.js';
+import { computeEmailHash } from './unsubscribeToken.js';
+
+/** Default max delivery attempts before an email is marked `failed`. */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+
+/**
+ * Map an email source to its feature toggle key under `Settings/email.features`.
+ * Sources with no dedicated toggle (`event`, `test`) are always allowed when the
+ * master switch is on.
+ */
+const SOURCE_FEATURE_KEY: Partial<Record<EmailSource, keyof NonNullable<EmailSettings['features']>>> = {
+  waitlist: 'waitlistEmails',
+  auth: 'authEmails',
+  payment: 'paymentEmails',
+  notification: 'notificationEmails',
+  broadcast: 'broadcasts',
+  drip: 'drips',
+};
+
+export interface QueueEmailParams {
+  /** Which feature is producing this email (drives the feature-toggle gate). */
+  source: EmailSource;
+  /** transactional vs marketing (drives consent/suppression rules). */
+  category: EmailCategory;
+  /** Recipient. */
+  toEmail: string;
+  toName?: string;
+  /** Sender identity (from the template). */
+  senderEmail: string;
+  senderName: string;
+  /** Raw subject / template HTML, still containing ##TAG## tokens. */
+  subject: string;
+  template: string;
+  /** Plain-text/preview fallback. */
+  text?: string;
+  /** Template type key (e.g. `waitlist_verify_otp_email`). */
+  type: string;
+  /** BCC address (admin copy). Resolved from settings when omitted. */
+  bcc?: string;
+  /**
+   * Whether the caller's template is active. Pass `false` to have the send
+   * skipped with `template_inactive`. Defaults to active.
+   */
+  templateIsActive?: boolean;
+  /**
+   * Marketing consent for this recipient (Phase 1: waitlist `isSubscribed`).
+   * When `false` and category is marketing, the send is skipped `unsubscribed`.
+   * Transactional emails ignore this.
+   */
+  isSubscribed?: boolean;
+  /** Extra tag data merged onto the log (otp, currency, price, waitlistName…). */
+  data?: Record<string, unknown>;
+  /** Override default max delivery attempts. */
+  maxAttempts?: number;
+  /**
+   * Pre-loaded `Settings/email` document (avoids a per-recipient read in hot
+   * paths such as broadcasts). When omitted, it is read once here.
+   */
+  emailSettings?: EmailSettings;
+}
+
+export interface QueueEmailResult {
+  id: string;
+  status: 'pending' | 'skipped' | 'suppressed';
+  skipReason?: EmailSkipReason;
+}
+
+/**
+ * The ONLY sanctioned way to create an `EmailLogs` document.
+ *
+ * Runs the kill-switch → feature-toggle → template-active → consent →
+ * suppression gates in order (spec §Phase-1). A blocked send is still written
+ * to `EmailLogs` (status `skipped`/`suppressed` + `skipReason`) so every
+ * decision is auditable — nothing is ever silently dropped.
+ *
+ * A `pending` doc fires `onEmailLogCreate` → `sendMail()`. Blocked docs are
+ * ignored by that trigger.
+ */
+export async function queueEmail(params: QueueEmailParams): Promise<QueueEmailResult> {
+  const settings = params.emailSettings ?? (await readEmailSettings());
+  const emailHash = computeEmailHash(params.toEmail);
+
+  const base = {
+    senderEmail: params.senderEmail,
+    senderName: params.senderName,
+    toName: params.toName || params.toEmail.split('@')[0] || '',
+    name: params.toName || params.toEmail.split('@')[0] || '',
+    toEmail: params.toEmail,
+    subject: params.subject,
+    template: params.template,
+    text: params.text || '',
+    bcc: params.bcc ?? settings?.bccEmail ?? '',
+    type: params.type,
+    category: params.category,
+    source: params.source,
+    emailHash,
+    attempts: 0,
+    maxAttempts: params.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    createdAt: Timestamp.now(),
+    ...(params.data || {}),
+  };
+
+  const blocked = (
+    status: 'skipped' | 'suppressed',
+    skipReason: EmailSkipReason,
+  ): Promise<QueueEmailResult> =>
+    writeLog({ ...base, status, skipReason }).then((id) => ({ id, status, skipReason }));
+
+  // 1. Master kill-switch — email disabled (or no provider configured).
+  if (!settings?.isEnabled || !settings?.activeProvider) {
+    return blocked('skipped', 'email_disabled');
+  }
+
+  // 2. Feature toggle — a feature OFF disables only that feature.
+  const featureKey = SOURCE_FEATURE_KEY[params.source];
+  if (featureKey && settings.features?.[featureKey] === false) {
+    return blocked('skipped', 'feature_disabled');
+  }
+
+  // 3. Template active check.
+  if (params.templateIsActive === false) {
+    return blocked('skipped', 'template_inactive');
+  }
+
+  // 4. Category / consent check (marketing only).
+  if (params.category === 'marketing' && params.isSubscribed === false) {
+    return blocked('skipped', 'unsubscribed');
+  }
+
+  // 5. Suppression check.
+  //    marketing ⇒ any suppression reason blocks;
+  //    transactional ⇒ only hard bounce/complaint block (protect reputation).
+  const suppression = await getSuppression(emailHash);
+  if (suppression) {
+    const hardReason = suppression.reason === 'bounce' || suppression.reason === 'complaint';
+    if (params.category === 'marketing' || hardReason) {
+      return blocked('suppressed', 'suppressed');
+    }
+  }
+
+  // 6. Passed all gates — enqueue for delivery.
+  const id = await writeLog({ ...base, status: 'pending' });
+  return { id, status: 'pending' };
+}
+
+async function writeLog(data: Record<string, unknown>): Promise<string> {
+  const ref = await db.collection('EmailLogs').add(data);
+  return ref.id;
+}
+
+async function readEmailSettings(): Promise<EmailSettings | undefined> {
+  try {
+    const snap = await db.collection('Settings').doc('email').get();
+    return snap.data() as EmailSettings | undefined;
+  } catch (err) {
+    console.error('queueEmail: failed to read Settings/email', err);
+    return undefined;
+  }
+}
+
+async function getSuppression(
+  emailHash: string,
+): Promise<{ reason: string } | undefined> {
+  try {
+    const snap = await db.collection('Suppression').doc(emailHash).get();
+    return snap.exists ? (snap.data() as { reason: string }) : undefined;
+  } catch (err) {
+    console.error('queueEmail: failed to read Suppression', err);
+    return undefined;
+  }
+}

--- a/functions/src/email-core/retryPendingEmails.ts
+++ b/functions/src/email-core/retryPendingEmails.ts
@@ -1,0 +1,55 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions/v2';
+import { Timestamp } from 'firebase-admin/firestore';
+import { db } from '../init.js';
+import { sendMail } from '../mail-config/mailConfig.js';
+import type { EmailLogData } from '../types.js';
+
+/** Max docs processed per run (bounds work; leftovers picked up next tick). */
+const MAX_PER_RUN = 100;
+
+/**
+ * Every 5 minutes, retry emails that are due for another attempt.
+ *
+ * Picks up `retrying` (transient send failures) and `deferred` (quota-exhausted)
+ * logs whose `nextAttemptAt` has passed and re-runs `sendMail`, which re-checks
+ * the kill-switch and quota on each attempt.
+ */
+export const retryPendingEmails = onSchedule(
+  { schedule: 'every 5 minutes', timeZone: 'UTC' },
+  async () => {
+    const now = Timestamp.now();
+    const seen = new Set<string>();
+    let processed = 0;
+
+    for (const status of ['retrying', 'deferred'] as const) {
+      if (processed >= MAX_PER_RUN) break;
+
+      let snap;
+      try {
+        snap = await db
+          .collection('EmailLogs')
+          .where('status', '==', status)
+          .where('nextAttemptAt', '<=', now)
+          .limit(MAX_PER_RUN - processed)
+          .get();
+      } catch (err) {
+        logger.error(`retryPendingEmails: query failed for status='${status}'`, err);
+        continue;
+      }
+
+      for (const doc of snap.docs) {
+        if (seen.has(doc.id)) continue;
+        seen.add(doc.id);
+        processed++;
+        try {
+          await sendMail(doc.data() as EmailLogData, doc.id);
+        } catch (err) {
+          logger.error(`retryPendingEmails: sendMail failed for ${doc.id}`, err);
+        }
+      }
+    }
+
+    logger.info(`retryPendingEmails: processed ${processed} due email(s).`);
+  },
+);

--- a/functions/src/email-core/unsubscribeToken.ts
+++ b/functions/src/email-core/unsubscribeToken.ts
@@ -1,0 +1,61 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { constant } from '../constant.js';
+
+/**
+ * Stable recipient key: sha256(lowercase(trim(email))).
+ * Same scheme as the existing `email_lookup` collection, so it can be used as a
+ * document id across Contacts / Suppression / signup_otps.
+ */
+export function computeEmailHash(email: string): string {
+  return createHash('sha256')
+    .update((email || '').trim().toLowerCase())
+    .digest('hex');
+}
+
+/**
+ * HMAC token binding an emailHash to the site's `unsubscribeSecret`.
+ * Only someone holding the secret (the server) can mint a valid token, so an
+ * unsubscribe link cannot be forged for an arbitrary address.
+ */
+export function buildUnsubscribeToken(emailHash: string, secret: string): string {
+  return createHmac('sha256', secret || '').update(emailHash).digest('hex');
+}
+
+/** Constant-time token validation. Returns false when secret/token are absent. */
+export function verifyUnsubscribeToken(
+  emailHash: string,
+  token: string,
+  secret: string,
+): boolean {
+  if (!emailHash || !token || !secret) return false;
+  const expected = buildUnsubscribeToken(emailHash, secret);
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(token, 'utf8');
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/** Base URL for public email links (unsubscribe / preferences). */
+export function getPublicBaseUrl(): string {
+  const base = constant.isProduction ? constant.live_url : constant.local_url;
+  // Guarantee a single trailing slash.
+  if (!base) return '/';
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+/**
+ * Build the one-click unsubscribe URL for a recipient.
+ * Fixes the historical empty-userId bug (emailTemplateHelper.ts:189): the link
+ * now carries the recipient's emailHash + an HMAC token instead of a blank id.
+ * Returns an empty string when no secret is configured (link can't be verified).
+ */
+export function buildUnsubscribeUrl(email: string, secret: string | undefined): string {
+  if (!email || !secret) return '';
+  const emailHash = computeEmailHash(email);
+  const token = buildUnsubscribeToken(emailHash, secret);
+  return `${getPublicBaseUrl()}unsubscribe?e=${emailHash}&t=${token}`;
+}

--- a/functions/src/email-log/broadcastHelper.ts
+++ b/functions/src/email-log/broadcastHelper.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from 'firebase-admin/firestore';
-import { db } from '../init.js';
-import type { BroadcastEmailDoc, RateLimitConfig, ProviderRateLimits } from '../types.js';
+import type { BroadcastEmailDoc, RateLimitConfig, ProviderRateLimits, EmailSettings } from '../types.js';
+import { queueEmail } from '../email-core/queueEmail.js';
 
 /** Convert legacy rate limit config to milliseconds-per-email delay
  * @deprecated Use getDelayFromLimits instead */
@@ -55,6 +55,8 @@ export async function processRecipientBatch(params: {
     initialFailedCount: number;
     /** Optional callback that returns false when daily/hourly quota is exhausted */
     quotaChecker?: () => Promise<boolean>;
+    /** Pre-loaded email settings (avoids a per-recipient Settings read in queueEmail) */
+    emailSettings?: EmailSettings;
 }): Promise<BatchProcessResult> {
     const {
         broadcastRef,
@@ -66,6 +68,7 @@ export async function processRecipientBatch(params: {
         initialSentCount,
         initialFailedCount,
         quotaChecker,
+        emailSettings,
     } = params;
 
     const delayMs = getDelayFromLimits(providerLimits);
@@ -104,22 +107,29 @@ export async function processRecipientBatch(params: {
 
         const recipient = recipients[i];
 
-        // Create EmailLog with retry logic
+        // Enqueue via the queueEmail() chokepoint with retry logic.
+        // Broadcasts are marketing: each recipient passes the suppression gate;
+        // skipped/suppressed recipients are still audited (blocked EmailLogs doc).
         let success = false;
         for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
-                await db.collection('EmailLogs').add({
-                    senderEmail: broadcastData.senderEmail,
-                    senderName: broadcastData.senderName,
+                await queueEmail({
+                    source: 'broadcast',
+                    category: 'marketing',
                     toEmail: recipient.toEmail,
                     toName: recipient.toName,
+                    senderEmail: broadcastData.senderEmail,
+                    senderName: broadcastData.senderName,
                     subject: broadcastData.subject,
                     template: broadcastData.template,
                     text: broadcastData.previewText || '',
                     type: 'broadcast',
-                    broadcastId,
-                    waitlistId: broadcastData.waitlistId,
-                    createdAt: Timestamp.now(),
+                    isSubscribed: true,
+                    emailSettings,
+                    data: {
+                        broadcastId,
+                        waitlistId: broadcastData.waitlistId,
+                    },
                 });
                 success = true;
                 sentCount++;

--- a/functions/src/email-log/continueBroadcast.ts
+++ b/functions/src/email-log/continueBroadcast.ts
@@ -73,10 +73,11 @@ export const continueBroadcast = onDocumentCreated(
 
         // Read active provider for quota checking
         let activeProvider = 'smtp';
+        let emailSettings: EmailSettings | undefined;
         try {
             const settingsSnap = await db.collection('Settings').doc('email').get();
-            const settings = settingsSnap.data() as EmailSettings | undefined;
-            activeProvider = settings?.activeProvider || 'smtp';
+            emailSettings = settingsSnap.data() as EmailSettings | undefined;
+            activeProvider = emailSettings?.activeProvider || 'smtp';
         } catch {
             /* use default */
         }
@@ -112,6 +113,7 @@ export const continueBroadcast = onDocumentCreated(
                 initialSentCount: broadcastData.sentCount || 0,
                 initialFailedCount: broadcastData.failedCount || 0,
                 quotaChecker,
+                emailSettings,
             });
 
             if (result.quotaExhausted) {

--- a/functions/src/email-log/createEmailLog.ts
+++ b/functions/src/email-log/createEmailLog.ts
@@ -15,6 +15,15 @@ export const onEmailLogCreate = onDocumentCreated('EmailLogs/{EmailLogsId}', asy
     return;
   }
 
+  // Only newly-queued docs are sendable. queueEmail() writes blocked sends with
+  // a terminal status (skipped/suppressed) and those must never be delivered.
+  // Retries of retrying/deferred docs are handled by retryPendingEmails, not here.
+  const status = (emailLogsData as EmailLogData).status;
+  if (status && status !== 'pending') {
+    console.log(`onEmailLogCreate: ${emailLogsId} has status '${status}', not sending.`);
+    return;
+  }
+
   try {
     await sendMail(emailLogsData as EmailLogData, emailLogsId);
   } catch (error) {

--- a/functions/src/email-log/processBroadcast.ts
+++ b/functions/src/email-log/processBroadcast.ts
@@ -39,11 +39,12 @@ export const processBroadcast = onDocumentCreated(
         // Resolve per-provider rate limits
         let activeProvider = 'smtp';
         let providerLimits: ProviderRateLimits = { perSecond: 1 };
+        let emailSettings: EmailSettings | undefined;
         try {
             const settingsSnap = await db.collection('Settings').doc('email').get();
-            const settings = settingsSnap.data() as EmailSettings | undefined;
-            activeProvider = settings?.activeProvider || 'smtp';
-            providerLimits = resolveProviderLimits(activeProvider, settings?.providerRateLimits);
+            emailSettings = settingsSnap.data() as EmailSettings | undefined;
+            activeProvider = emailSettings?.activeProvider || 'smtp';
+            providerLimits = resolveProviderLimits(activeProvider, emailSettings?.providerRateLimits);
         } catch (err) {
             console.warn('processBroadcast: Could not read settings, using defaults:', err);
         }
@@ -90,6 +91,7 @@ export const processBroadcast = onDocumentCreated(
                 initialSentCount: broadcastData.sentCount || 0,
                 initialFailedCount: broadcastData.failedCount || 0,
                 quotaChecker,
+                emailSettings,
             });
 
             if (result.quotaExhausted) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,11 @@
 
 export * from './email-log/createEmailLog.js';
 
+// Email-core (Phase 1): one-click unsubscribe endpoint + retry scheduler.
+// queueEmail() is a library helper (imported by senders), not an exported trigger.
+export * from './email-core/handleUnsubscribe.js';
+export * from './email-core/retryPendingEmails.js';
+
 export * from './publishQueue/processPublishQueue.js';
 
 export * from './content-types/onContentTypeDelete.js';

--- a/functions/src/mail-config/mailConfig.ts
+++ b/functions/src/mail-config/mailConfig.ts
@@ -3,9 +3,17 @@ import { constant } from '../constant.js';
 import { db } from '../init.js';
 import nodemailer from 'nodemailer';
 import { EmailLogData, EmailSettings, ProcessedTemplate } from '../types.js';
-import { incrementSendCount } from './emailCounter.js';
+import { checkQuota, incrementSendCount, resolveProviderLimits } from './emailCounter.js';
 import { getMiscSettings } from '../shared/site-settings.js';
 import { POWERED_BY_EMAIL_HTML } from '../shared/html-document.js';
+import { buildUnsubscribeUrl } from '../email-core/unsubscribeToken.js';
+
+/** Base retry backoff unit: 5 minutes. */
+const RETRY_BASE_MS = 5 * 60 * 1000;
+/** Delay before re-checking a quota-deferred send. */
+const QUOTA_DEFER_MS = 15 * 60 * 1000;
+/** Default max delivery attempts (mirrors queueEmail DEFAULT_MAX_ATTEMPTS). */
+const DEFAULT_MAX_ATTEMPTS = 3;
 
 /**
  * Build a 1x1 tracking-pixel <img> tag.
@@ -22,19 +30,49 @@ export async function sendMail(emailLogsData: EmailLogData, emailLogsId: string)
 
     const logRef = db.collection('EmailLogs').doc(emailLogsId);
 
+    const currentAttempts = emailLogsData.attempts || 0;
+    const maxAttempts = emailLogsData.maxAttempts || DEFAULT_MAX_ATTEMPTS;
+
     let updatedTemplate: ProcessedTemplate | undefined;
     let activeProvider = 'smtp';
 
-    try {
-        const settings = settingsEmailDoc.data();
-        const isEnabled = settings?.isEnabled;
+    const settings = settingsEmailDoc.data() as EmailSettings | undefined;
 
-        if (!isEnabled) {
-            console.log('Email sending is disabled in settings.');
+    // Belt-and-braces kill-switch (chokepoint 2): if email was disabled after
+    // this doc was queued, mark it skipped rather than sending. Re-checked on
+    // every retry attempt too.
+    if (!settings?.isEnabled || !settings?.activeProvider) {
+        console.log('Email sending is disabled in settings.');
+        await logRef.update({
+            status: 'skipped',
+            skipReason: 'email_disabled',
+            sendingTime: Timestamp.now(),
+        });
+        return;
+    }
+
+    activeProvider = settings.activeProvider || 'smtp';
+
+    // Universal quota/rate-limit enforcement for ALL sends (spec §Phase-1.3).
+    // Exhausted ⇒ defer and let retryPendingEmails pick it up when quota resets.
+    try {
+        const limits = resolveProviderLimits(activeProvider, settings.providerRateLimits);
+        const quota = await checkQuota(activeProvider, limits);
+        if (!quota.ok) {
+            console.warn(`sendMail: quota exhausted for ${activeProvider}; deferring ${emailLogsId}.`);
+            await logRef.update({
+                status: 'deferred',
+                skipReason: 'quota',
+                nextAttemptAt: Timestamp.fromMillis(Date.now() + QUOTA_DEFER_MS),
+                activeProvider,
+            });
             return;
         }
+    } catch (quotaErr) {
+        console.warn('sendMail: quota check failed, proceeding with send:', quotaErr);
+    }
 
-        activeProvider = settings?.activeProvider || 'smtp';
+    try {
         updatedTemplate = await processEmailTemplate(emailLogsData, settings);
 
         // Conditionally append "Powered by Arc CMS" branding
@@ -47,23 +85,27 @@ export async function sendMail(emailLogsData: EmailLogData, emailLogsId: string)
             console.warn('Failed to check showPoweredBy setting, skipping branding:', brandingErr);
         }
 
+        // Marketing sends carry List-Unsubscribe headers (RFC 2369 / 8058).
+        const unsubHeaders = buildListUnsubscribeHeaders(emailLogsData, settings);
+
         let result;
 
         switch (activeProvider) {
             case 'resend':
-                result = await sendResendMail(emailLogsData, updatedTemplate, settings);
+                result = await sendResendMail(emailLogsData, updatedTemplate, settings, unsubHeaders);
                 break;
             case 'gmail':
-                result = await sendGmailMail(emailLogsData, updatedTemplate, settings);
+                result = await sendGmailMail(emailLogsData, updatedTemplate, settings, unsubHeaders);
                 break;
             case 'smtp':
             default:
-                result = await sendSmtpMail(emailLogsData, updatedTemplate, settings);
+                result = await sendSmtpMail(emailLogsData, updatedTemplate, settings, unsubHeaders);
                 break;
         }
 
         const updateData: Record<string, any> = {
             status: 'success',
+            attempts: currentAttempts + 1,
             sendingTime: Timestamp.now(),
             processedSubject: updatedTemplate.subject,
             processedTemplate: updatedTemplate.template,
@@ -85,12 +127,22 @@ export async function sendMail(emailLogsData: EmailLogData, emailLogsId: string)
             console.warn('Failed to increment email counter:', counterErr);
         }
     } catch (err) {
+        // Transient failure ⇒ retry with exponential backoff until maxAttempts.
+        const newAttempts = currentAttempts + 1;
+        const exhausted = newAttempts >= maxAttempts;
+
         const failData: Record<string, any> = {
-            status: 'failed',
+            status: exhausted ? 'failed' : 'retrying',
+            attempts: newAttempts,
             sendingTime: Timestamp.now(),
             activeProvider,
             errorMessage: err instanceof Error ? err.message : String(err),
         };
+        if (!exhausted) {
+            failData.nextAttemptAt = Timestamp.fromMillis(
+                Date.now() + RETRY_BASE_MS * Math.pow(2, newAttempts),
+            );
+        }
         if (updatedTemplate) {
             failData.processedSubject = updatedTemplate.subject;
             failData.processedTemplate = updatedTemplate.template;
@@ -98,11 +150,32 @@ export async function sendMail(emailLogsData: EmailLogData, emailLogsId: string)
             failData.unmappedTags = updatedTemplate.unmappedTags;
         }
         await logRef.update(failData);
-        console.error('Error sending email:', err);
+        console.error(
+            `Error sending email ${emailLogsId} (attempt ${newAttempts}/${maxAttempts}, ${exhausted ? 'failed' : 'will retry'}):`,
+            err,
+        );
     }
 }
 
-async function sendSmtpMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings) {
+/**
+ * Build List-Unsubscribe / List-Unsubscribe-Post headers for marketing sends.
+ * Returns an empty object for transactional email or when no unsubscribe URL
+ * can be built (missing secret).
+ */
+function buildListUnsubscribeHeaders(
+    emailLogsData: EmailLogData,
+    settings: EmailSettings,
+): Record<string, string> {
+    if (emailLogsData.category !== 'marketing') return {};
+    const url = buildUnsubscribeUrl(emailLogsData.toEmail, settings.unsubscribeSecret);
+    if (!url) return {};
+    return {
+        'List-Unsubscribe': `<${url}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+    };
+}
+
+async function sendSmtpMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings, extraHeaders: Record<string, string> = {}) {
     const smtpSettings = settings?.smtp || {} as Partial<import('../types.js').SmtpConfig>;
 
     const transporterMail = nodemailer.createTransport({
@@ -123,10 +196,11 @@ async function sendSmtpMail(emailLogsData: EmailLogData, updatedTemplate: Proces
         replyTo: settings.replyToEmail,
         html: updatedTemplate.template + buildTrackingPixel(emailLogsData.id ?? ''),
         bcc: emailLogsData.bcc || undefined,
+        headers: extraHeaders,
     });
 }
 
-async function sendResendMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings) {
+async function sendResendMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings, extraHeaders: Record<string, string> = {}) {
     const resendConfig = settings?.resend;
     if (!resendConfig?.apiKey) {
         throw new Error('Resend API Key is missing');
@@ -146,6 +220,7 @@ async function sendResendMail(emailLogsData: EmailLogData, updatedTemplate: Proc
             html: updatedTemplate.template + buildTrackingPixel(emailLogsData.id ?? ''),
             text: emailLogsData.text,
             reply_to: settings.replyToEmail,
+            ...(Object.keys(extraHeaders).length ? { headers: extraHeaders } : {}),
         }),
     });
 
@@ -158,7 +233,7 @@ async function sendResendMail(emailLogsData: EmailLogData, updatedTemplate: Proc
     return { messageId: data.id };
 }
 
-async function sendGmailMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings) {
+async function sendGmailMail(emailLogsData: EmailLogData, updatedTemplate: ProcessedTemplate, settings: EmailSettings, extraHeaders: Record<string, string> = {}) {
     const gmailSettings = settings?.gmail || {} as Partial<import('../types.js').GmailConfig>;
     const transporter = nodemailer.createTransport({
         service: 'gmail',
@@ -177,6 +252,7 @@ async function sendGmailMail(emailLogsData: EmailLogData, updatedTemplate: Proce
         html: updatedTemplate.template + buildTrackingPixel(emailLogsData.id ?? ''),
         replyTo: settings.replyToEmail || undefined,
         bcc: emailLogsData.bcc || undefined,
+        headers: extraHeaders,
     });
 }
 
@@ -186,9 +262,9 @@ export async function processEmailTemplate(
     configData: EmailSettings | undefined,
     customReplacements?: Record<string, string | (() => string)>
 ): Promise<ProcessedTemplate> {
-    const unsubscribe_link = constant.isProduction
-        ? `${constant.live_url}unsubscribe?userId=${''}`
-        : `${constant.local_url}unsubscribe?userId=${''}`;
+    // HMAC-token unsubscribe link keyed by the recipient's emailHash — fixes the
+    // historical empty-userId bug. Empty when no unsubscribeSecret is configured.
+    const unsubscribe_link = buildUnsubscribeUrl(emailLogsData.toEmail, configData?.unsubscribeSecret);
 
     // Default tag mappings - automatically maps tags to data paths
     const defaultMappings: Record<string, () => string> = {

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -26,6 +26,39 @@ export interface WaitlistUserData {
   [key: string]: any;
 }
 
+/** Email category — drives consent/suppression rules (see spec §2.3). */
+export type EmailCategory = 'transactional' | 'marketing';
+
+/** Which feature produced an email — used for the per-feature toggle gate. */
+export type EmailSource =
+  | 'waitlist'
+  | 'auth'
+  | 'payment'
+  | 'notification'
+  | 'broadcast'
+  | 'drip'
+  | 'event'
+  | 'test';
+
+/** EmailLogs.status lifecycle (spec §3.4). */
+export type EmailLogStatus =
+  | 'pending'
+  | 'success'
+  | 'failed'
+  | 'retrying'
+  | 'deferred'
+  | 'skipped'
+  | 'suppressed';
+
+/** Why a send was blocked before/at send time (spec §3.4). */
+export type EmailSkipReason =
+  | 'email_disabled'
+  | 'feature_disabled'
+  | 'template_inactive'
+  | 'unsubscribed'
+  | 'suppressed'
+  | 'quota';
+
 export interface EmailLogData {
   id?: string;
   senderEmail: string;
@@ -44,13 +77,28 @@ export interface EmailLogData {
   waitlistName?: string;
   referralLink?: string;
   leaderboardLink?: string;
+  // ── Email-core pipeline fields (Phase 1) ──
+  /** transactional vs marketing — controls consent/suppression rules */
+  category?: EmailCategory;
+  /** Which feature produced this email */
+  source?: EmailSource;
+  /** sha256(lowercase(trim(toEmail))) — stable recipient key, matches email_lookup scheme */
+  emailHash?: string;
+  /** Delivery attempts so far (0 when freshly queued) */
+  attempts?: number;
+  /** Max delivery attempts before giving up (default 3) */
+  maxAttempts?: number;
+  /** When the next retry/deferred send should be attempted */
+  nextAttemptAt?: Timestamp;
+  /** Reason a send was blocked (set alongside status skipped/suppressed/deferred) */
+  skipReason?: EmailSkipReason;
   // Post-send processed data
   processedSubject?: string;
   processedTemplate?: string;
   usedTags?: string[];
   unmappedTags?: string[];
   activeProvider?: string;
-  status?: string;
+  status?: EmailLogStatus;
   sendingTime?: Timestamp;
   messageId?: string;
   errorMessage?: string;
@@ -109,6 +157,32 @@ export interface AutoPurgeConfig {
   retentionDays: number;
 }
 
+/**
+ * Per-feature email toggles (spec §3.1). All default TRUE and are moot when
+ * the master `isEnabled` is false. A feature toggle OFF disables only that
+ * feature's email delivery.
+ */
+export interface EmailFeatureToggles {
+  /** OTP + welcome + waitlist broadcasts */
+  waitlistEmails?: boolean;
+  /** signup OTP + welcome-on-signup */
+  authEmails?: boolean;
+  /** payment lifecycle + trial/updates reminders */
+  paymentEmails?: boolean;
+  /** notification → email delivery */
+  notificationEmails?: boolean;
+  broadcasts?: boolean;
+  drips?: boolean;
+  /** instant admin alerts + daily digest */
+  adminAlerts?: boolean;
+}
+
+/** Admin digest configuration (spec §3.1) */
+export interface AdminDigestConfig {
+  enabled: boolean;
+  hourUtc: number;
+}
+
 /** Shape of the Firestore Settings/email document */
 export interface EmailSettings {
   isEnabled?: boolean;
@@ -123,12 +197,22 @@ export interface EmailSettings {
   /** Legacy flat SMTP credentials (before nested smtp object) */
   smtpUser?: string;
   smtpPassword?: string;
+  bccEmail?: string;
   /** Rate limit for broadcast sending (legacy) */
   rateLimit?: RateLimitConfig;
   /** Per-provider rate limits (new). Overrides legacy rateLimit when present. */
   providerRateLimits?: Record<string, ProviderRateLimits>;
   /** Auto-purge old email logs */
   autoPurge?: AutoPurgeConfig;
+  // ── Email-core additions (Phase 1) ──
+  /** Per-feature email toggles */
+  features?: EmailFeatureToggles;
+  /** E4 — require email verification on signup (default false) */
+  requireSignupVerification?: boolean;
+  /** Daily admin digest config (default disabled, 08:00 UTC) */
+  adminDigest?: AdminDigestConfig;
+  /** Random secret used to sign one-click unsubscribe tokens (generated once) */
+  unsubscribeSecret?: string;
 }
 
 /** Schema for BroadcastEmails document processed server-side */

--- a/functions/src/utils/emailTemplateHelper.ts
+++ b/functions/src/utils/emailTemplateHelper.ts
@@ -1,7 +1,7 @@
-import { Timestamp } from 'firebase-admin/firestore';
 import { db } from '../init.js';
 // constant import removed
-import { EmailTemplateData, WaitlistUserData, EmailLogData } from '../types.js';
+import { EmailTemplateData, WaitlistUserData } from '../types.js';
+import { queueEmail } from '../email-core/queueEmail.js';
 
 /**
  * Fetches an email template, preferring the waitlist-specific one over the global config.
@@ -38,72 +38,57 @@ export async function getEmailTemplate(
 
 /**
  * Creates an email log for OTP verification.
+ * Transactional — routed through the queueEmail() chokepoint.
  */
 export async function createOtpEmailLog(
   userData: WaitlistUserData,
   templateData: EmailTemplateData
 ): Promise<void> {
-  // Fetch settings for BCC
-  let bccEmail = '';
-  try {
-    const settingsDoc = await db.collection('Settings').doc('email').get();
-    if (settingsDoc.exists) {
-      bccEmail = settingsDoc.data()?.bccEmail || '';
-    }
-  } catch (e) { console.error('Error fetching settings', e); }
-
-  const emailObj: EmailLogData = {
+  const toName = userData.firstName || userData.name || userData.email.split('@')[0];
+  await queueEmail({
+    source: 'waitlist',
+    category: 'transactional',
+    toEmail: userData.email,
+    toName,
     senderEmail: templateData.senderEmail,
     senderName: templateData.senderName,
-    toName: userData.firstName || userData.name || userData.email.split('@')[0],
-    name: userData.firstName || userData.name || userData.email.split('@')[0],
-    toEmail: userData.email,
     subject: templateData.subject,
     template: templateData.template,
     text: templateData.previewText || '',
-    bcc: bccEmail,
     type: 'waitlist_verify_otp_email',
-    createdAt: Timestamp.now(),
-    otp: userData.verificationCode,
-  };
-
-  await db.collection('EmailLogs').add(emailObj);
+    templateIsActive: templateData.isActive !== false,
+    data: { otp: userData.verificationCode },
+  });
 }
 
 /**
  * Creates an email log for welcome email.
+ * Marketing — respects the recipient's subscription state + suppression list.
  */
 export async function createWelcomeEmailLog(
   userData: WaitlistUserData,
   templateData: EmailTemplateData,
   waitlistName: string = ''
 ): Promise<void> {
-  // Fetch settings for BCC
-  let bccEmail = '';
-  try {
-    const settingsDoc = await db.collection('Settings').doc('email').get();
-    if (settingsDoc.exists) {
-      bccEmail = settingsDoc.data()?.bccEmail || '';
-    }
-  } catch (e) { console.error('Error fetching settings', e); }
-
-  const emailObj: EmailLogData = {
+  const toName = userData.firstName || userData.name || userData.email.split('@')[0];
+  await queueEmail({
+    source: 'waitlist',
+    category: 'marketing',
+    toEmail: userData.email,
+    toName,
     senderEmail: templateData.senderEmail,
     senderName: templateData.senderName,
-    toName: userData.firstName || userData.name || userData.email.split('@')[0],
-    name: userData.firstName || userData.name || userData.email.split('@')[0],
-    toEmail: userData.email,
     subject: templateData.subject,
     template: templateData.template,
     text: templateData.previewText || '',
-    bcc: bccEmail,
     type: 'waitlist_welcome_email',
-    createdAt: Timestamp.now(),
-    waitlistName: waitlistName,
-    referralLink: userData.referralLink || '',
-    leaderboardLink: userData.leaderboardLink || '',
-    position: userData.queuePosition,
-  };
-
-  await db.collection('EmailLogs').add(emailObj);
+    templateIsActive: templateData.isActive !== false,
+    isSubscribed: userData.isSubscribed !== false,
+    data: {
+      waitlistName,
+      referralLink: userData.referralLink || '',
+      leaderboardLink: userData.leaderboardLink || '',
+      position: userData.queuePosition,
+    },
+  });
 }

--- a/src/app/pages/(onboarding)/onboarding-setup.service.spec.ts
+++ b/src/app/pages/(onboarding)/onboarding-setup.service.spec.ts
@@ -173,6 +173,51 @@ describe('OnboardingSetupService', () => {
             mockSetDoc.mockRejectedValueOnce(new Error('fail'));
             await expect(service.saveEmailConfig({ isEnabled: true } as any)).rejects.toThrow('fail');
         });
+
+        // E6: onboarding must apply the same "no enable without a valid provider"
+        // coercion the Email Settings page uses.
+        describe('E6 valid-provider guard', () => {
+            it('enables email when the chosen provider config is valid (gmail)', async () => {
+                await service.saveEmailConfig({
+                    activeProvider: 'gmail',
+                    gmail: { user: 'a@gmail.com', password: 'app-pass' },
+                } as any);
+
+                expect(mockSetDoc.mock.calls[0][1]).toEqual(expect.objectContaining({ isEnabled: true }));
+                expect(mockSetDoc.mock.calls[1][1]).toEqual({ isEnabled: true });
+            });
+
+            it('enables email for a valid smtp config', async () => {
+                await service.saveEmailConfig({
+                    activeProvider: 'smtp',
+                    smtp: { host: 'smtp.x.com', port: 587, secure: false, user: 'u', password: 'p' },
+                } as any);
+                expect(mockSetDoc.mock.calls[1][1]).toEqual({ isEnabled: true });
+            });
+
+            it('enables email for a valid resend config', async () => {
+                await service.saveEmailConfig({
+                    activeProvider: 'resend',
+                    resend: { apiKey: 're_123' },
+                } as any);
+                expect(mockSetDoc.mock.calls[1][1]).toEqual({ isEnabled: true });
+            });
+
+            it('keeps email DISABLED when the provider config is incomplete', async () => {
+                await service.saveEmailConfig({
+                    activeProvider: 'gmail',
+                    gmail: { user: 'a@gmail.com', password: '' }, // missing password
+                } as any);
+
+                expect(mockSetDoc.mock.calls[0][1]).toEqual(expect.objectContaining({ isEnabled: false }));
+                expect(mockSetDoc.mock.calls[1][1]).toEqual({ isEnabled: false });
+            });
+
+            it('keeps email DISABLED when no provider is selected', async () => {
+                await service.saveEmailConfig({ senderEmail: 'x@y.com' } as any);
+                expect(mockSetDoc.mock.calls[1][1]).toEqual({ isEnabled: false });
+            });
+        });
     });
 
     describe('saveEmailSkipped', () => {

--- a/src/app/pages/(onboarding)/onboarding-setup.service.ts
+++ b/src/app/pages/(onboarding)/onboarding-setup.service.ts
@@ -10,7 +10,7 @@ import { inject, Injectable } from '@angular/core';
 import { Firestore, doc, collection, setDoc, getDoc, serverTimestamp } from '@angular/fire/firestore';
 import { Observable, from, map, of, catchError } from 'rxjs';
 import { DEFAULT_CONTENT_TYPES, DEFAULT_WAITLIST, DEFAULT_SITE_CSS_URLS } from './onboarding-defaults';
-import { DEFAULT_EMAIL_SETTINGS, IEmailSettings } from '../admin/(settings)/email-setting/email-setting.model';
+import { DEFAULT_EMAIL_SETTINGS, IEmailSettings, hasValidProviderConfig } from '../admin/(settings)/email-setting/email-setting.model';
 
 @Injectable({ providedIn: 'root' })
 export class OnboardingSetupService {
@@ -65,18 +65,24 @@ export class OnboardingSetupService {
 
     /**
      * Save email configuration with the chosen provider.
+     *
+     * E6 invariant: email can only be enabled when a valid provider is
+     * configured — the same coercion the Email Settings page applies. Without a
+     * valid provider, we persist the config but keep email disabled so the
+     * kill-switch (queueEmail/sendMail) never sends against a broken provider.
      */
     async saveEmailConfig(settings: IEmailSettings): Promise<void> {
+        const enable = hasValidProviderConfig(settings);
         const dataToSave = {
             ...settings,
-            isEnabled: true,
+            isEnabled: enable,
             createdAt: serverTimestamp(),
             updatedAt: serverTimestamp(),
         };
         delete dataToSave.id;
 
         await setDoc(doc(this.firestore, 'Settings', 'email'), dataToSave);
-        await setDoc(doc(this.firestore, 'Settings', 'email_status'), { isEnabled: true });
+        await setDoc(doc(this.firestore, 'Settings', 'email_status'), { isEnabled: enable });
     }
 
     /**

--- a/src/app/pages/admin/(settings)/email-setting/email-setting.model.ts
+++ b/src/app/pages/admin/(settings)/email-setting/email-setting.model.ts
@@ -62,6 +62,51 @@ export interface IAutoPurgeConfig {
 }
 
 /**
+ * Per-feature email toggles (spec §3.1).
+ * All default TRUE and are moot when the master `isEnabled` is off.
+ */
+export interface IEmailFeatureToggles {
+    /** OTP + welcome + waitlist broadcasts */
+    waitlistEmails: boolean;
+    /** signup OTP + welcome-on-signup */
+    authEmails: boolean;
+    /** payment lifecycle + trial/updates reminders */
+    paymentEmails: boolean;
+    /** notification → email delivery */
+    notificationEmails: boolean;
+    broadcasts: boolean;
+    drips: boolean;
+    /** instant admin alerts + daily digest */
+    adminAlerts: boolean;
+}
+
+/** Default feature toggles — everything on. */
+export const DEFAULT_EMAIL_FEATURES: IEmailFeatureToggles = {
+    waitlistEmails: true,
+    authEmails: true,
+    paymentEmails: true,
+    notificationEmails: true,
+    broadcasts: true,
+    drips: true,
+    adminAlerts: true,
+};
+
+/** UI metadata for rendering the Features toggle group. */
+export const EMAIL_FEATURE_META: Array<{
+    key: keyof IEmailFeatureToggles;
+    label: string;
+    description: string;
+}> = [
+    { key: 'waitlistEmails', label: 'Waitlist emails', description: 'OTP, welcome & waitlist broadcasts' },
+    { key: 'authEmails', label: 'Account emails', description: 'Signup OTP & welcome-on-signup' },
+    { key: 'paymentEmails', label: 'Payment emails', description: 'Receipts, trial & renewal reminders' },
+    { key: 'notificationEmails', label: 'Notification emails', description: 'Email delivery of in-app notifications' },
+    { key: 'broadcasts', label: 'Broadcasts', description: 'One-off campaign sends' },
+    { key: 'drips', label: 'Drip campaigns', description: 'Automated sequences' },
+    { key: 'adminAlerts', label: 'Admin alerts', description: 'Instant admin alerts & daily digest' },
+];
+
+/**
  * Email Settings Model
  */
 export interface IEmailSettings {
@@ -94,6 +139,29 @@ export interface IEmailSettings {
     providerRateLimits?: Record<string, IProviderRateLimits>;
     /** Auto-purge old email logs */
     autoPurge?: IAutoPurgeConfig;
+    /** Per-feature email toggles (spec §3.1) */
+    features?: IEmailFeatureToggles;
+    /** E4 — require email verification on signup (default false) */
+    requireSignupVerification?: boolean;
+}
+
+/**
+ * Whether `settings` carries a valid provider configuration.
+ * Mirrors the Email Settings page's `isProviderConfigValid()` but operates on
+ * plain data so callers without a live provider component (e.g. the onboarding
+ * wizard, E6) can enforce the same "no enable without a valid provider" rule.
+ */
+export function hasValidProviderConfig(settings: Partial<IEmailSettings>): boolean {
+    switch (settings.activeProvider) {
+        case 'smtp':
+            return !!settings.smtp?.host && !!settings.smtp?.user && !!settings.smtp?.password;
+        case 'gmail':
+            return !!settings.gmail?.user && !!settings.gmail?.password;
+        case 'resend':
+            return !!settings.resend?.apiKey;
+        default:
+            return false;
+    }
 }
 
 /**
@@ -142,6 +210,8 @@ export const DEFAULT_EMAIL_SETTINGS: IEmailSettings = {
         enabled: true,
         retentionDays: 60,
     },
+    features: { ...DEFAULT_EMAIL_FEATURES },
+    requireSignupVerification: false,
 };
 
 /**

--- a/src/app/pages/admin/(settings)/email-setting/email-setting.page.html
+++ b/src/app/pages/admin/(settings)/email-setting/email-setting.page.html
@@ -242,6 +242,59 @@
             </mat-card-content>
         </mat-card>
 
+        <!-- Feature Toggles -->
+        <mat-card class="mb-4">
+            <mat-card-header>
+                <mat-card-title>
+                    <i class="fa-solid fa-sliders me-2"></i>
+                    Email Features
+                </mat-card-title>
+                <mat-card-subtitle>
+                    Turn individual email types on or off. The master switch above overrides all of these.
+                </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content class="pt-3">
+                @if (!emailEnabled()) {
+                <div class="alert alert-warning d-flex align-items-center gap-2 mb-3" role="alert">
+                    <i class="fa-solid fa-triangle-exclamation"></i>
+                    <span>Email is turned off. Enable email above to configure and use these features.</span>
+                </div>
+                }
+
+                <div formGroupName="features" class="feature-toggle-list">
+                    @for (f of featureMeta; track f.key) {
+                    <div class="feature-toggle-row d-flex align-items-start justify-content-between gap-3 py-2">
+                        <div class="feature-toggle-label">
+                            <div class="fw-medium">{{ f.label }}</div>
+                            <div class="text-muted small">{{ f.description }}</div>
+                        </div>
+                        <mat-slide-toggle
+                            [formControlName]="f.key"
+                            color="primary"
+                            [disabled]="!emailEnabled()"
+                            (change)="onFeatureToggleChange()">
+                        </mat-slide-toggle>
+                    </div>
+                    }
+                </div>
+
+                <hr class="my-3" />
+
+                <div class="feature-toggle-row d-flex align-items-start justify-content-between gap-3 py-2">
+                    <div class="feature-toggle-label">
+                        <div class="fw-medium">Require email verification on signup</div>
+                        <div class="text-muted small">New users must confirm their email via a one-time code before their account is verified. Forced off while email is disabled.</div>
+                    </div>
+                    <mat-slide-toggle
+                        formControlName="requireSignupVerification"
+                        color="primary"
+                        [disabled]="!emailEnabled()"
+                        (change)="onFeatureToggleChange()">
+                    </mat-slide-toggle>
+                </div>
+            </mat-card-content>
+        </mat-card>
+
         <!-- Action Buttons -->
         <div class="action-section">
             <div class="d-flex justify-content-between align-items-center">

--- a/src/app/pages/admin/(settings)/email-setting/email-setting.page.ts
+++ b/src/app/pages/admin/(settings)/email-setting/email-setting.page.ts
@@ -24,7 +24,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { BaseComponent } from '../../../../../shared/components/base/base.component';
 import { EmailSettingService } from './email-setting.service';
 import { TestConnectionDialogComponent } from './test-connection-dialog.component';
-import { EMAIL_PROVIDERS, EmailProvider, IEmailSettings, PROVIDER_DEFAULT_LIMITS } from './email-setting.model';
+import { DEFAULT_EMAIL_FEATURES, EMAIL_FEATURE_META, EMAIL_PROVIDERS, EmailProvider, IEmailSettings, PROVIDER_DEFAULT_LIMITS } from './email-setting.model';
 import { IEmailProviderComponent } from './providers/email-provider-base';
 import { SmtpProviderComponent } from './providers/smtp-provider.component';
 import { GmailProviderComponent } from './providers/gmail-provider.component';
@@ -59,6 +59,7 @@ export default class EmailSettingPageComponent extends BaseComponent implements 
 
     emailForm!: FormGroup;
     providers = EMAIL_PROVIDERS;
+    featureMeta = EMAIL_FEATURE_META;
 
     emailEnabled = signal(false);
     /** True while the admin is configuring a provider but email is not yet enabled. */
@@ -118,7 +119,22 @@ export default class EmailSettingPageComponent extends BaseComponent implements 
                 enabled: [true],
                 retentionDays: [60, [Validators.required, Validators.min(1), Validators.max(365)]],
             }),
+            features: this.fb.group({
+                waitlistEmails: [DEFAULT_EMAIL_FEATURES.waitlistEmails],
+                authEmails: [DEFAULT_EMAIL_FEATURES.authEmails],
+                paymentEmails: [DEFAULT_EMAIL_FEATURES.paymentEmails],
+                notificationEmails: [DEFAULT_EMAIL_FEATURES.notificationEmails],
+                broadcasts: [DEFAULT_EMAIL_FEATURES.broadcasts],
+                drips: [DEFAULT_EMAIL_FEATURES.drips],
+                adminAlerts: [DEFAULT_EMAIL_FEATURES.adminAlerts],
+            }),
+            requireSignupVerification: [false],
         });
+    }
+
+    /** The features FormGroup — used by the template's toggle rows. */
+    get featuresGroup(): FormGroup {
+        return this.emailForm.get('features') as FormGroup;
     }
 
     private setupFormChangeListener(): void {
@@ -166,6 +182,8 @@ export default class EmailSettingPageComponent extends BaseComponent implements 
                     rateLimit: settings.rateLimit,
                     providerRateLimits: settings.providerRateLimits,
                     autoPurge: settings.autoPurge,
+                    features: { ...DEFAULT_EMAIL_FEATURES, ...(settings.features || {}) },
+                    requireSignupVerification: settings.requireSignupVerification ?? false,
                 });
 
                 this.emailEnabled.set(settings.isEnabled);
@@ -269,6 +287,16 @@ export default class EmailSettingPageComponent extends BaseComponent implements 
 
     isProviderConfigValid(): boolean {
         return this.activeProviderComponent()?.isConfigValid() ?? false;
+    }
+
+    /**
+     * Persist a Features / verification toggle change immediately.
+     * These are independent of provider-connection testing, so we save directly
+     * (type=true bypasses the "test connection first" gate).
+     */
+    onFeatureToggleChange(): void {
+        this.emailForm.markAsDirty();
+        this.onSubmit(true);
     }
 
     /** Build the full IEmailSettings object from shared form + all provider caches */


### PR DESCRIPTION
Build the email-core chokepoint and route every sender through it.

Backend (functions/src/email-core/):
- queueEmail(): the only sanctioned EmailLogs writer. Gates in order — master kill-switch → feature toggle → template-active → consent → suppression. Blocked sends write an auditable skipped/suppressed log with skipReason (never silent).
- HMAC unsubscribe tokens (unsubscribeToken.ts): computeEmailHash + buildUnsubscribeUrl fix the empty-userId bug (emailTemplateHelper.ts:189); links are /unsubscribe?e={emailHash}&t={hmac}.
- handleUnsubscribe HTTP fn: validates token, writes Suppression doc, flips legacy waitlist isSubscribed. GET → confirmation page; POST → RFC 8058 one-click.
- retryPendingEmails scheduled fn (every 5m): re-sends due retrying/deferred logs, re-checking the kill-switch each attempt.

sendMail hardening (mail-config/mailConfig.ts):
- belt-and-braces kill-switch (skipped/email_disabled)
- universal quota enforcement for all sends (deferred/quota + nextAttemptAt)
- retry with exponential backoff (retrying → failed at maxAttempts), attempts counter
- List-Unsubscribe / List-Unsubscribe-Post headers on marketing sends
- onEmailLogCreate now only delivers pending docs

Sender migration → queueEmail(): waitlist OTP/welcome, payment emails, broadcast recipient batches (settings threaded to avoid per-recipient reads).

Frontend:
- Email Settings: Features toggle group (master switch gates them) + E4 requireSignupVerification toggle (forced-off when email disabled).
- E6: onboarding saveEmailConfig applies the same valid-provider coercion as the settings page (no enable without a working provider).

Types: EmailSettings.features/requireSignupVerification/adminDigest/ unsubscribeSecret; EmailLogData category/source/emailHash/attempts/ status/skipReason.

Tests (Vitest, all green): queueEmail gating matrix, E5 no-direct- EmailLogs-writes source scan, HMAC token round-trip/tamper, handleUnsubscribe, retryPendingEmails, sendMail hardening, onEmailLogCreate guard, E6 onboarding guard. Migrated emailTemplateHelper spec to assert queueEmail delegation.